### PR TITLE
Address review follow-ups for v0.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sunwood-ai-labs/github-kanban-mcp-server",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sunwood-ai-labs/github-kanban-mcp-server",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sunwood-ai-labs/github-kanban-mcp-server",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A Model Context Protocol server for managing GitHub issues as Kanban using gh CLI",
   "main": "build/index.js",
   "type": "module",

--- a/src/handlers/comment-handlers.ts
+++ b/src/handlers/comment-handlers.ts
@@ -1,5 +1,5 @@
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
-import { ghAsync, writeToTempFile, removeTempFile } from '../utils/exec.js';
+import { ghAsync, tempMarkdownFileName, writeToTempFile, removeTempFile } from '../utils/exec.js';
 import { ToolResponse } from '../types.js';
 
 function validateRepo(repo: string): void {
@@ -25,20 +25,21 @@ function validateIssueNumber(issueNumber: string): void {
  */
 export async function handleAddComment(args: {
   repo: string;
-  issue_number: string;
+  issue_number: string | number;
   body: string;
   state?: 'open' | 'closed';
 }): Promise<ToolResponse> {
-  const tempFile = 'comment_body.md';
+  const tempFile = tempMarkdownFileName('comment-body');
+  const issueNumber = String(args.issue_number);
   validateRepo(args.repo);
-  validateIssueNumber(args.issue_number);
+  validateIssueNumber(issueNumber);
 
   try {
     // ステータスの変更が指定されている場合は先に処理
     if (args.state) {
       try {
         const command = args.state === 'closed' ? 'close' : 'reopen';
-        await ghAsync(['issue', command, args.issue_number, '--repo', args.repo]);
+        await ghAsync(['issue', command, issueNumber, '--repo', args.repo]);
         console.log(`Issue status changed to ${args.state}`);
       } catch (error) {
         console.error('Failed to change issue status:', error);
@@ -55,7 +56,7 @@ export async function handleAddComment(args: {
       await ghAsync([
         'issue',
         'comment',
-        args.issue_number,
+        issueNumber,
         '--repo',
         args.repo,
         '--body-file',
@@ -74,7 +75,7 @@ export async function handleAddComment(args: {
       const { stdout: issueData } = await ghAsync([
         'issue',
         'view',
-        args.issue_number,
+        issueNumber,
         '--repo',
         args.repo,
         '--json',

--- a/src/handlers/issue-handlers.ts
+++ b/src/handlers/issue-handlers.ts
@@ -1,6 +1,6 @@
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import { IssueArgs, CreateIssueArgs, UpdateIssueArgs, ToolResponse } from '../types.js';
-import { ghAsync, writeToTempFile, removeTempFile } from '../utils/exec.js';
+import { ghAsync, tempMarkdownFileName, writeToTempFile, removeTempFile } from '../utils/exec.js';
 import { getExistingLabels, createLabel } from './label-handlers.js';
 import { getRepoInfoFromGitConfig } from '../utils/repo-info.js';
 
@@ -71,7 +71,7 @@ export async function handleListIssues(args: IssueArgs): Promise<ToolResponse> {
  */
 export async function handleCreateIssue(args: CreateIssueArgs): Promise<ToolResponse> {
   const { owner, repo } = await getRepoInfo(args);
-  const tempFile = 'issue_body.md';
+  const tempFile = tempMarkdownFileName('issue-body');
 
   try {
     // ラベルの存在確認と作成
@@ -146,7 +146,7 @@ export async function handleUpdateIssue(args: UpdateIssueArgs): Promise<ToolResp
   const { owner, repo } = await getRepoInfo(args);
   const issueNumber = issueNumberArg(args.issue_number);
 
-  const tempFile = 'update_body.md';
+  const tempFile = tempMarkdownFileName('update-body');
 
   try {
     // 状態の更新を処理

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'child_process';
+import { randomUUID } from 'crypto';
 import { promisify } from 'util';
 import { join } from 'path';
 import fs from 'fs/promises';
@@ -7,6 +8,10 @@ export const execFileAsync = promisify(execFile);
 
 export async function ghAsync(args: string[]): Promise<{ stdout: string; stderr: string }> {
   return await execFileAsync('gh', args);
+}
+
+export function tempMarkdownFileName(prefix: string): string {
+  return `${prefix}-${randomUUID()}.md`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Convert `add_comment` issue numbers to strings before passing them to `execFile` argument arrays
- Use unique markdown temp filenames for create/update/comment bodies to avoid concurrent request races
- Bump package version to `0.4.2` for the follow-up release

## Addresses
- PR #27 Gemini Code Assist comments on runtime `issue_number` typing
- PR #27 Gemini Code Assist comments on fixed temporary body filenames

## Verification
- `npm run build`
- `npm audit --omit=dev --json` reports 0 production vulnerabilities
- residual search found no `exec(` usage
